### PR TITLE
fix: dotenv can not load

### DIFF
--- a/pilot/configs/__init__.py
+++ b/pilot/configs/__init__.py
@@ -1,0 +1,14 @@
+import os
+import random
+import sys
+
+from dotenv import load_dotenv
+
+if "pytest" in sys.argv or "pytest" in sys.modules or os.getenv("CI"):
+    print("Setting random seed to 42")
+    random.seed(42)
+
+# Load the users .env file into environment variables
+load_dotenv(verbose=True, override=True)
+
+del load_dotenv


### PR DESCRIPTION
for now change .env do not work
because we change the config -> configs and in that we do not load the dotenv
this bug brings from commit https://github.com/csunny/DB-GPT/commit/4bd45747ad078808498126b67d0b0bf2a4f27f95
and I am not sure if we can delete `pilot/server/__init__.py`  we need to check.
@csunny
fix: #88 
