### PR TITLE
Fixed the issue when the MySQL table name had the keyword in it

### DIFF
--- a/pilot/common/sql_database.py
+++ b/pilot/common/sql_database.py
@@ -419,14 +419,14 @@ class Database:
     def get_indexes(self, table_name):
         """Get table indexes about specified table."""
         session = self._db_sessions()
-        cursor = session.execute(text(f"SHOW INDEXES FROM {table_name}"))
+        cursor = session.execute(text(f"SHOW INDEXES FROM `{table_name}`"))
         indexes = cursor.fetchall()
         return [(index[2], index[4]) for index in indexes]
 
     def get_show_create_table(self, table_name):
         """Get table show create table about specified table."""
         session = self._db_sessions()
-        cursor = session.execute(text(f"SHOW CREATE TABLE  {table_name}"))
+        cursor = session.execute(text(f"SHOW CREATE TABLE  `{table_name}`"))
         ans = cursor.fetchall()
         res = ans[0][1]
         res = re.sub(r"\s*ENGINE\s*=\s*InnoDB\s*", " ", res, flags=re.IGNORECASE)


### PR DESCRIPTION
When a table name with special characters, such as trigger, exists in the database, the following error is reported.
```log
2023-07-25 00:02:47 | ERROR | stderr | sqlalchemy.exc.ProgrammingError: (pymysql.err.ProgrammingError) (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'trigger' at line 1")
2023-07-25 00:02:47 | ERROR | stderr | [SQL: SHOW INDEXES FROM trigger]
```